### PR TITLE
Allowing relaxation zones at outflow instead of numerical beach.

### DIFF
--- a/amr-wind/ocean_waves/regular_waves/RegularWaves.H
+++ b/amr-wind/ocean_waves/regular_waves/RegularWaves.H
@@ -24,9 +24,10 @@ struct RegularWavesBaseData
 
     amrex::Real beach_length{8.0};
 
-    amrex::Real x_start_beach{22.0};
-
     bool has_ramp{false};
+
+    bool has_beach{true};
+    bool has_outprofile{false};
 
     amrex::Real ramp_period{2.0};
 };


### PR DESCRIPTION
- specified using the argument "relax_zone_out_length" instead of 
"numerical_beach_length". 
- fixed the line that finds the inflow relaxation zone to work with 
domains that don't start at x = 0.
- eliminated redundancy by removing the specification of 
numerical_beach_start. Only the length is necessary.